### PR TITLE
Enable Interrupt Before Leaving FPU Safe IRQ Handler

### DIFF
--- a/src/portable/AM335X/bsp_platform.c
+++ b/src/portable/AM335X/bsp_platform.c
@@ -96,6 +96,7 @@ void vApplicationFPUSafeIRQHandler(void)
     portDI();
     xInsideISR = Local_xInsideISR;
     IntPriorityThresholdSet(portUNMASK_VALUE);
+    IntSystemEnable(index);
 }
 
 


### PR DESCRIPTION
The FPUSafeIRQHandler does not "re" enable the interrupt after it is handled. Therefore each IRQ at index "x" can only be handled by a defined ISR once.